### PR TITLE
Fix compilation errors, now rebar compatible.

### DIFF
--- a/ebin/erlog.app
+++ b/ebin/erlog.app
@@ -12,7 +12,7 @@
              erlog_parse,
              erlog_scan,
              erlog_shell,
-	     user_pl.erl]},
+	     user_pl]},
   {registered, []},
   {applications, [kernel,stdlib]}
  ]}.

--- a/src/erlog_parse.erl
+++ b/src/erlog_parse.erl
@@ -29,6 +29,7 @@
 -export([term/1,term/2,format_error/1]).
 -export([prefix_op/1,infix_op/1,postfix_op/1]).
 
+-compile({nowarn_unused_function, [val/1]}).
 %% -compile(export_all).
 
 term(Toks) -> term(Toks, 1).
@@ -73,8 +74,8 @@ term([{'{',_}|Toks0], Prec, Next) ->
     term(Toks0, 1200,
 	 fun (Toks1, Term) ->
 		 expect(Toks1, '}', Term,
-			fun (Toks2, Term) ->
-				rest_term(Toks2, {'{}',Term}, 0, Prec, Next)
+			fun (Toks2, Term1) ->
+				rest_term(Toks2, {'{}',Term1}, 0, Prec, Next)
 			end)
 	 end);
 term([{'[',_},{']',_}|Toks], Prec, Next) ->
@@ -140,8 +141,8 @@ bracket_term(Toks0, Prec, Next) ->
     term(Toks0, 1200,
 	 fun (Toks1, Term) ->
 		 expect(Toks1, ')', Term,
-			fun (Toks2, Term) ->
-				rest_term(Toks2, Term, 0, Prec, Next)
+			fun (Toks2, Term1) ->
+				rest_term(Toks2, Term1, 0, Prec, Next)
 			end)
 	 end).
 

--- a/src/user_pl.erl
+++ b/src/user_pl.erl
@@ -24,14 +24,19 @@
 
 -export([assert/1,app_3/6,rev_2/6,mem_2/6]).
 
--import(erlog_int, [add_binding/3,unify/3,deref/2,dderef/2,
-		    prove_body/5,unify_prove_body/7,fail/2,
+-import(erlog_int, [add_binding/3,
+                    %% unify/3,
+                    %% deref/2,
+                    dderef/2,
+		    %% prove_body/5,
+                    unify_prove_body/7,
+                    fail/2,
 		    add_compiled_proc/4]).
 -import(lists, [foldl/3]).
 
 %% Define the choice point record
 -record(cp, {type,label,data,next,bs,vn}).
--record(cut, {label,next}).
+%%-record(cut, {label,next}).
 
 assert(Db) ->
     foldl(fun ({Head,M,F}, LDb) -> 


### PR DESCRIPTION
There are only a few concerns I have about this patch, namely the "shadowed variable" errors in `erlog_parse.erl`. Otherwise, this allows compilation on R15B03-1 to succeed, with rebar.
